### PR TITLE
Add imageRotation getter

### DIFF
--- a/lib/flutter_camera_ml_vision.dart
+++ b/lib/flutter_camera_ml_vision.dart
@@ -123,6 +123,7 @@ class CameraMlVisionState<T> extends State<CameraMlVision<T>> {
   }
 
   CameraValue get cameraValue => _cameraController?.value;
+  ImageRotation get imageRotation => _rotation;
 
   Future<void> _initialize() async {
     if (Platform.isAndroid) {


### PR DESCRIPTION
Make imageRotation accessible from outside packages to allow bbox scaling according to lens rotation. Also see https://github.com/santetis/flutter_camera_ml_vision/issues/13