### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_ml_vision: ^0.8.0
+  firebase_ml_vision: ^0.9.0
   path_provider: ^1.1.0
   pedantic: ^1.4.0
   device_info: ^0.4.0+1


### PR DESCRIPTION
Use the latest version because it fixes bug causing memory leak with iOS images

Additionally you should see the release notes of ml vision:
"Breaking Change: Add capability to release resources held by detectors with close() method. You should now call detector.close() when a detector will no longer be used."

- I have not included this