### PR TITLE
_cameraController intializer takePicture

### DIFF
--- a/lib/flutter_camera_ml_vision.dart
+++ b/lib/flutter_camera_ml_vision.dart
@@ -142,8 +142,10 @@ class CameraMlVisionState<T> extends State<CameraMlVision<T>> {
     await _cameraController.startImageStream(_processImage);
   }
 
-  Future<void> Function(String path) get takePicture =>
-      _cameraController.takePicture;
+  Future<void> takePicture(String path) async {
+    await _cameraController.initialize();
+    await _cameraController.takePicture(path);
+  }
 
   Future<void> _initialize() async {
     if (Platform.isAndroid) {


### PR DESCRIPTION
fixed camera initialization await before takePicture method being called, other wise the following exception was thrown:
`Exception has occurred. CameraException (CameraException(error, CaptureRequest contains unconfigured Input/Output Surface!))`

Fixes for issue: https://github.com/rushio-consulting/flutter_camera_ml_vision/issues/62#